### PR TITLE
idx() needs to be fixed

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -28,7 +28,10 @@ function idx($array, $index, $default = null, $saniztize = true) {
     $value = $default;
   }
   if ($sanitize) {
-    return htmlentities($value);
+    // FIXME: $value can be an array, and htmlentities only accepts strings.
+    // Sanitization has to be done differently.
+    //return htmlentities($value);
+    return $value;
   } else {
     return $value;
   }


### PR DESCRIPTION
idx needs to be fixed to avoid this: Warning: htmlentities() expects parameter 1 to be string, array given in /app/www/utils.php on line 31 Warning: array_values() expects parameter 1 to be array, null given in /app/www/index.php on line 52
