### PR TITLE
Treat any `<a class="facebook-button">...</a>` as a generic button.

### DIFF
--- a/stylesheets/base.css
+++ b/stylesheets/base.css
@@ -110,6 +110,7 @@ header .tagline {
   font-weight: bold;
   line-height: 20px;
   margin: 0;
+  padding: 0 7px;
   outline: none;
   text-decoration: none;
   text-shadow: 0 1px 1px rgba(255, 255, 255, .33);
@@ -117,19 +118,19 @@ header .tagline {
 
 .facebook-button span {
   background: url("../images/sprites.png") no-repeat;
-  padding: 0 7px 0 21px;
+  padding-left: 14px;
 }
 
 .facebook-button .speech-bubble {
-  background-position: 6px 3px;
+  background-position: 0 3px;
 }
 
 .facebook-button .plus {
-  background-position: 6px -17px;
+  background-position: 0 -17px;
 }
 
 .facebook-button .apprequests {
-  background-position: 6px -37px;
+  background-position: 0 -37px;
 }
 
 .button:link, .button:visited {


### PR DESCRIPTION
This patch allows app developers to use HTML like `<a href="…" class="facebook-button">…</a>` to create a generic button. Previously, for button-like spacing, there needed to be a `<span>` that also had to have one of three classes that matched a sprite image. This is awkward in cases where the sprite images don't really match the button functionality. For instance, the HTML to implement a logout button might look like `<a href="<?php print $FB->getLogoutUrl();?>" class="facebook-button"><span>Log out of Facebook</span></a>`, but this would result in a "speech bubble" icon appearing next to the "log out" button. Dropping the `<span>` and applying the generic spacing CSS to the `facebook-button` class directly is clearer and more semantically appropriate.
